### PR TITLE
Switch to reusable workflow and add v* tags trigger

### DIFF
--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -3,64 +3,12 @@ on:
   push:
     branches:
       - main
+    tags:
+      - v*
   pull_request:
-env:
-  go_version: 1.21.6
 jobs:
-  golangci-lint:
-    name: golangci-lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Pin Golang version for linting
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.go_version }}
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: v1.55.2
-  test:
-    name: go test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.go_version }}
-      - name: Set up gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: go-test-${{ hashFiles('**/go.sum') }}
-          restore-keys: go-test-
-      - name: Run go test
-        run: |
-          set -euo pipefail
-          go generate
-          go test -coverprofile /tmp/coverage.out -json -v ./... 2>&1 | tee /tmp/gotest.log | gotestfmt
-          echo "# Code coverage summary" > /tmp/coverage.md
-          echo "|File|Type|Coverage|" >> /tmp/coverage.md
-          echo "|----|----|--------|" >> /tmp/coverage.md
-          go tool cover -func /tmp/coverage.out | sed -e 's/\s\s*/|/g' -e 's/^/|/g' -e 's/$/|/g' >> /tmp/coverage.md
-          
-          cat /tmp/coverage.md >> $GITHUB_STEP_SUMMARY
-          echo "::group::Code coverage summary"
-          go tool cover -func /tmp/coverage.out
-          echo "::endgroup::"
-      - name: Upload test log
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: test-results
-          path: |
-            /tmp/gotest.log
-            /tmp/coverage.out
-            /tmp/coverage.md
-          if-no-files-found: error
+  lint_and_test:
+    name: lint and test
+    uses: arcalot/arcaflow-reusable-workflows/.github/workflows/go_lint_and_test.yaml@main
+    with:
+      go_version: ${{ vars.ARCALOT_GO_VERSION }}


### PR DESCRIPTION
## Changes introduced with this PR

Replace the workflow for this repo with an invocation of the common reusable workflow, and use the common version of Go.  Also, add the conventional tags-based trigger.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).